### PR TITLE
Fixed "join us" button

### DIFF
--- a/index.html
+++ b/index.html
@@ -675,7 +675,7 @@
                     >
                   </li>
                   <li><a href="./pages/tutorial.html">Tutorials</a></li>
-                  <li><a href="#">Join Us!</a></li>
+                  <li><a href="https://github.com/Opentek-Org/support">Join Us!</a></li>
                 </ul>
               </div>
             </div>


### PR DESCRIPTION
# Related Issues
- "join us" button was not working
  
# Proposed Changes
- Changed ahref value from "#" to the desired link - "https://github.com/Opentek-Org/support"

  
# Additional Information
- NIL
  

