### PR TITLE
Fixed the 404 error

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Please read our [`CODE OF CONDUCT`](CODE_OF_CONDUCT.md), and the process for sub
 
 ## 🤷‍♂️ Want to submit an event, program, project or a tutorial to our Website?
 
-Please read [CONTRIBUTE.md](https://github.com/Opentek-Org/opentek/blob/main/CONTRIBUTE.md)
+Please read [CONTRIBUTING.md](https://github.com/Opentek-Org/opentek/blob/main/CONTRIBUTING.md)
 
 ## 💻 Built with
 


### PR DESCRIPTION
Clicking on CONTRIBUTE.md in README was throwing 404 error page
I fixed the error by adding the correct URL for CONTRIBUTING.md page in Readme.md

# Related Issues
- issue goes here
  
# Proposed Changes
- Change 1
- Change 2
  
# Additional Information
- Any additional information or context
  
# Checklist
- [x] Tests
- [x] Translations
- [x] Documentations

# Screenshots

Original             |  Updated
:-------------------------:|:-------------------------:
** Original Screenshot **  |  ** Updated Screenshot **
