### PR TITLE
Social Icons gap

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1135,6 +1135,7 @@ li {
 }
 
 .footer-social i {
+
   width: 45px;
   height: 45px;
   border: 1px solid #fff;
@@ -1148,6 +1149,7 @@ li {
   -webkit-transition: all linear 0.3s;
   -o-transition: all linear 0.3s;
   transition: all linear 0.3s;
+  margin-bottom: 12px;
 }
 
 .footer-social i:hover {


### PR DESCRIPTION
 Adding a bottom margin space between social icons in small devices.

![Screenshot (8)](https://github.com/Opentek-Org/opentek/assets/72201773/90d91738-01bd-47bb-ad63-d35534a58b28)
