### PR TITLE
Positioned The Setting Icon to Navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -320,6 +320,9 @@
             </ul>
           </div>
         </div>
+        <div class="setting"  onclick="translatex()">
+          <i class="fa-solid fa-gear setting-icon" ></i>
+      </div>
       </nav>
     </header>  
       <!-- HEADER AREA ENDS -->
@@ -762,9 +765,7 @@
                 <i class="fa-solid fa-lightbulb" ></i>
                 
             </div> -->
-            <div class="setting"  onclick="translatex()">
-                <i class="fa-solid fa-gear setting-icon" ></i>
-            </div>
+            
         </div>
 
         <div class="theams">


### PR DESCRIPTION


# Related Issues
The setting icon on the homepage should be moved to the top right corner of the navigation bar for a neater and easier-to-use layout.

https://github.com/Opentek-Org/opentek/assets/77961384/5f6100d5-ce75-410f-ae82-c07d42a4f85c

  
# Proposed Changes
- Change 1
-I relocated the setting icon from below the navigation bar on the home page to the top right corner of the navbar.

https://github.com/Opentek-Org/opentek/assets/77961384/4a66b67c-5aac-40da-87e4-a98dee372ae5


  
# Additional Information
- Any additional information or context
  
# Checklist
- [ ] Tests
- [ ] Translations
- [ ] Documentations

# Screenshots
Original

<img width="958" alt="image" src="https://github.com/Opentek-Org/opentek/assets/77961384/7ae89f0d-50cd-4cff-9e43-572969ff130f">

After
<img width="960" alt="image" src="https://github.com/Opentek-Org/opentek/assets/77961384/25c7050e-6aa8-477c-be9b-6e1a42b1bdc4">


Original             |  Updated
:-------------------------:|:-------------------------:
** Original Screenshot **  |  ** Updated Screenshot **
