### PR TITLE
feat: made social anchors accessible ✨

### DIFF
--- a/index.html
+++ b/index.html
@@ -611,25 +611,52 @@
                   ~ Linus Torvalds
                 </p>
                 <div class="footer-social">
-                  <a href="https://discord.gg/9qyr4Mdc3Y" target="_blank"
-                    ><i class="fab fa-discord" aria-hidden="true"></i
-                  ></a>
-                  <a href="https://twitter.com/opentekorg" target="_blank"
-                    ><i class="fab fa-twitter" aria-hidden="true"></i
-                  ></a>
+                  <a 
+		    href="https://discord.gg/9qyr4Mdc3Y" 
+		    target="_blank"
+		    aria-label="Join with us on Discord"
+	            title="Discord (External Link)"
+	            rel="noopener noreferrer"
+                  >
+			<i class="fab fa-discord" aria-hidden="true"></i>
+		  </a>
+			
+                  <a 
+		    href="https://twitter.com/opentekorg" 
+		    target="_blank"
+		    aria-label="Follow us on Iwitter"
+	            title="Twitter (External Link)"
+	            rel="noopener noreferrer"
+                  >
+		        <i class="fab fa-twitter" aria-hidden="true"></i>
+		  </a>
                   <a
                     href="https://www.linkedin.com/company/opentekorg/"
                     target="_blank"
-                    ><i class="fab fa-linkedin-in" aria-hidden="true"></i
-                  ></a>
-                  <a href="mailto:opentekorg@gmail.com" target="_blank"
-                    ><i class="fas fa-envelope" aria-hidden="true"></i
-                  ></a>
+		    aria-label="Follow us on Linkedin"
+	            title="Linkedin (External Link)"
+	            rel="noopener noreferrer"
+                  >
+			 <i class="fab fa-linkedin-in" aria-hidden="true"></i>
+		  </a>
+                  <a 
+		    href="mailto:opentekorg@gmail.com"
+		    target="_blank"
+		    aria-label="Mail us on"
+	            title="Preferred Mail Application (External Link)"
+	            rel="noopener noreferrer"
+                  >
+			 <i class="fas fa-envelope" aria-hidden="true"></i>
+		  </a>
                   <a
                     href="https://github.com/Opentek-Org/opentek"
                     target="_blank"
-                    ><i class="fab fa-github" aria-hidden="true"></i
-                  ></a>
+		    aria-label="Follow us on Github"
+	            title="Github (External Link)"
+	            rel="noopener noreferrer"
+                  >
+			 <i class="fab fa-github" aria-hidden="true"></i>
+		  </a>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
# Related Issues
Close #494 
  
# Proposed Changes
- Added `aria-label` attribute for social anchors like Instagram & Twitter
- The `aria-label` attribute is important for screen readers because it provides a text label for an object, such as `a` with social icons. When a screen reader encounters the object, the `aria-label` text is read so that the user will know what it is. 
- This is important for people who are blind or have low vision, as they rely on screen readers to access the web.
- Improved `title` attribute's data, because the title attribute is intended to provide additional information to screen reader users.
- And along with that i added `rel` for the anchors which are lacking them to ensure best practices for crawlers
- Because adding the `rel="noopener noreferrer"` attribute can help to protect this website from security vulnerabilities and improve performance. It is a good practice to use this attribute on all external links.
- Overall this PR is intended to make necessary changes to meet best practices for crawlers along with improving accessibility for social anchors
  
  
# Checklist
- [x] Tests
- [x] Translations
- [x] Documentations

# Screenshots
- We can't take screenshots of accessibility changes rather than code changes, Accessibility changes are often invisible to the user because it's intended to guide disabled people
