### PR TITLE
docs: add workflow to assign PR to its author

### DIFF
--- a/.github/workflows/author-assign-pr.yml
+++ b/.github/workflows/author-assign-pr.yml
@@ -1,0 +1,17 @@
+# Reference: https://github.com/toshimaru/auto-author-assign
+name: "Author Assign"
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v1.6.2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}" # GITHUB_TOKEN will be used by default


### PR DESCRIPTION
# Related Issues
Closes #511 
  
# Proposed Changes
- Reference: https://github.com/toshimaru/auto-author-assign
- The purpose of this workflow is to automatically assign the author of the pull request. It uses the provided `GitHub token`  
(`secrets.GITHUB_TOKEN`) to perform this action.
- By using this workflow, the author of a pull request will be automatically assigned when the pull request is opened or reopened in the repository.

## Code

```yml
name: "Author Assign"

on:
  pull_request_target:
    types: [opened, reopened]

permissions:
  pull-requests: write

jobs:
  assign-author:
    runs-on: ubuntu-latest
    steps:
      - uses: toshimaru/auto-author-assign@v1.6.2
        with:
          repo-token: "${{ secrets.GITHUB_TOKEN }}" # GITHUB_TOKEN will be used by default
```

# Checklist
- [ ] Tests
- [ ] Translations
- [x] Documentations

