### PR TITLE
docs: workflow to add labels after analyzing titles of PR

### DIFF
--- a/.github/labeler-config.yml
+++ b/.github/labeler-config.yml
@@ -1,0 +1,56 @@
+filters:
+  - label: "goal: new-feature"
+    regexs:
+      - /\bfeat\b/
+      - /feature/i
+    events: [pull_request]
+    targets: [title]
+
+  - label: "documentation"
+    regexs:
+      - /docs/i
+    events: [pull_request]
+    targets: [title]
+
+  - label: "bug"
+    regexs:
+      - /bug/i
+    events: [pull_request]
+    targets: [title]
+  - label: "bug"
+    regexs:
+      - /fix/i
+    events: [pull_request]
+    targets: [title]
+
+  - label: "chore"
+    regexs:
+      - /\btypo\b/
+      - /typo/i
+    events: [pull_request]
+    targets: [title]
+
+  - label: "chore"
+    regexs:
+      - /description/i
+    events: [pull_request]
+    targets: [title]
+
+  - label: "chore"
+    regexs:
+      - /chore/i
+    events: [pull_request]
+    targets: [title]
+
+  - label: "goal: build"
+    regexs:
+      - /build/i
+    events: [pull_request]
+    targets: [title]
+
+  - label: "goal: refactor"
+    regexs:
+      - /\brefactor\b/
+      - /refactor/i
+    events: [pull_request]
+    targets: [title]

--- a/.github/workflows/add-pr-labels.yml
+++ b/.github/workflows/add-pr-labels.yml
@@ -1,0 +1,24 @@
+# reference: https://github.com/hoho4190/issue-pr-labeler
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read # to read configuration yml file
+      pull-requests: write # to add labels to pull requests
+
+    steps:
+      - name: Run PR Labeler
+        uses: hoho4190/issue-pr-labeler@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file-name: labeler-config.yml
+        #   disable-bot: true  # this will prevent issues, PRs created by bots


### PR DESCRIPTION
Reference: https://github.com/hoho4190/issue-pr-labeler

> Please review carefully as getting wrong labels will pose lot of problems.

# Related Issues
Closes #512 
  
## About Regex Expression

You can test it here: https://regex101.com/

I am taking two examples, which `you must read so that you can properly review the PR`.

- `/\bfeat\b/`: This regular expression matches the exact word "feat" with word boundaries (`\b`). It will match strings that contain the word "feat" as a whole word, but not if it's part of another word (e.g., "defeat" or "feature").

- `/feature/i`: This regular expression matches the word "feature" (case-insensitive) anywhere within a string. It will match strings that contain "feature" in any combination of uppercase and lowercase letters (e.g., "Feature", "FEATURE", "feature").

## Changes proposed

- I have checked issue forms and corresponding labels to properly use the config workflow.
- I have used following labels, since `there was none in the repository. Kindly add them`, or let me know the changes (different labels)
   - Label - keywords (if keywords found in the title of PR, then corresponding label is added)
   - goal: new-feature - `feat/feature`
   - documentation - `docs`
   - bug - `bug/fix`
   - chore - `chore/typo/description`
   - goal: refactor - `refactor`
   - goal: build - `build`
- I didn't found anything related to adding multiple labels at once, so I have used 1 label for 1 set.
  
# Additional Information
- This can be done for issues as well, but since there is labels already attached to the issue forms, so I didn't create the same. Let me know if you need for the issues.
  
# Checklist
- [ ] Tests
- [ ] Translations
- [x] Documentations
